### PR TITLE
Ensure local copy of orientdb4r is loaded, not the installed gem

### DIFF
--- a/test/readme_sample.rb
+++ b/test/readme_sample.rb
@@ -1,3 +1,4 @@
+  $: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
   require 'orientdb4r'
 
   CLASS = 'myclass'

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_ddo.rb
+++ b/test/test_ddo.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_dmo.rb
+++ b/test/test_dmo.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_document_crud.rb
+++ b/test/test_document_crud.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_loadbalancing.rb
+++ b/test/test_loadbalancing.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+$: << File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'orientdb4r'
 
 ###


### PR DESCRIPTION
Without setting the load path, a simple 'require' will load the installed orientdb4r gem, not the one from the checked out git repo.
