### PR TITLE
Add Gemfile & rake as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -92,8 +92,8 @@ see Wiki page for more sample at https://github.com/veny/orientdb4r/wiki
 
 
   > cd /path/to/repository
-  > rake db:setup4test  # to create the temp DB which doesn't seem to be a default since v1.5
-  > rake test
+  > bundle exec rake db:setup4test  # to create the temp DB which doesn't seem to be a default since v1.5
+  > bundle exec rake test
 
 Make sure before starting the tests:
 * database server is running on localhost:2480

--- a/orientdb4r.gemspec
+++ b/orientdb4r.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |s|
   s.license = 'Apache License, v2.0'
 
   s.add_dependency(%q<rest-client>, ["~> 1.6.7"])
+
+  s.add_development_dependency "rake", ">= 10.3"
 #  s.add_development_dependency(%q<json>, ["~> 1.5.1"])
 
 end


### PR DESCRIPTION
This PR adds a Gemfile, ignores Gemfile.lock (since we're in a gem, we don't want to freeze versions), and adds rake as a development dependency
This should allow everybody to run tests