### PR TITLE
Fix content type header for rest-client

### DIFF
--- a/lib/orientdb4r/rest/restclient_node.rb
+++ b/lib/orientdb4r/rest/restclient_node.rb
@@ -18,6 +18,11 @@ module Orientdb4r
       opts[:url] = "#{url}/#{opts[:uri]}"
       opts.delete :uri
 
+      if content_type = opts.delete(:content_type)
+        opts[:headers] ||= {}
+        opts[:headers][:content_type] = content_type
+      end
+
       # data
       data = opts.delete :data
       data = '' if data.nil? and :post == opts[:method] # POST has to have data

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -86,6 +86,23 @@ class TestClient < Test::Unit::TestCase
       end
     end
   end
+end
 
+class TestClientUseJson < Test::Unit::TestCase
+  def setup
+    @client = Orientdb4r.client
+    @client.connect database: 'temp', user: 'admin', password: 'admin'
+    @client.create_class('test_client_uses_json')
+  end
 
+  def teardown
+    @client.drop_class('test_client_uses_json')
+  end
+
+  def test_content_type_is_json
+    doc = @client.create_document('@class' => 'test_client_uses_json', 'name' => '+')
+
+    # with nothing specified, rest-client url encodes payload, so "+" becomes " "
+    assert_equal '+', doc['name']
+  end
 end


### PR DESCRIPTION
This PR fixes the content-type used by rest-client. Headers must be passed in a hash under `headers` (see. https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb#L18)