### PR TITLE
Orientdb2

### DIFF
--- a/lib/orientdb4r/rest/client.rb
+++ b/lib/orientdb4r/rest/client.rb
@@ -152,7 +152,7 @@ module Orientdb4r
         :user => :optional, :password => :optional
       }
       verify_and_sanitize_options(options, options_pattern)
-      verify_options(options.select {|k,v| k === :storage or k === :type}, {:storage => [:memory, :local], :type => [:document, :graph]})
+      verify_options(options.select {|k,v| k === :storage or k === :type}, {:storage => [:memory, :plocal], :type => [:document, :graph]})
 
       params = { :method => :post, :uri => "database/#{options[:database]}/#{options[:storage].to_s}/#{options[:type].to_s}" }
       params[:no_session] = true # out of existing session which represents an already done authentication

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -96,7 +96,7 @@ class TestDatabase < Test::Unit::TestCase
 
     # create non-default DB: storage=local;type=graph
     assert_nothing_thrown do
-      @client.create_database :database => 'UniT', :user => 'root', :password => 'root', :storage => :local, :type => :graph
+      @client.create_database :database => 'UniT', :user => 'root', :password => 'root', :storage => :plocal, :type => :graph
       @client.delete_database :database => 'UniT', :user => 'root', :password => 'root'
     end
   end

--- a/test/test_document_crud.rb
+++ b/test/test_document_crud.rb
@@ -37,6 +37,8 @@ class TestDocumentCrud < Test::Unit::TestCase
     assert_not_nil doc.doc_rid
     assert_instance_of Orientdb4r::Rid, doc.doc_rid
     assert_equal CLASS, doc.doc_class
+
+    # FAIL: https://github.com/orientechnologies/orientdb/issues/3656
     assert_equal 0, doc.doc_version
 
     # no effect if a define the version
@@ -73,6 +75,8 @@ class TestDocumentCrud < Test::Unit::TestCase
     doc = @client.get_document created.doc_rid
     assert_equal CLASS, doc.doc_class
     assert_equal created.doc_rid, doc.doc_rid
+
+    # FAIL: https://github.com/orientechnologies/orientdb/issues/3657
     assert_equal 0, doc.doc_version
     assert_equal 'd', doc.doc_type
     assert_equal 1, doc['prop1']

--- a/test/test_document_crud.rb
+++ b/test/test_document_crud.rb
@@ -38,12 +38,13 @@ class TestDocumentCrud < Test::Unit::TestCase
     assert_instance_of Orientdb4r::Rid, doc.doc_rid
     assert_equal CLASS, doc.doc_class
 
-    # FAIL: https://github.com/orientechnologies/orientdb/issues/3656
-    assert_equal 0, doc.doc_version
+    # https://github.com/orientechnologies/orientdb/issues/3656
+    assert doc.doc_version >= 1
 
     # no effect if a define the version
-    doc = @client.create_document({ '@class' => CLASS, '@version' => 2, 'prop1' => 1, 'prop2' => 'text' })
-    assert_equal 0, doc.doc_version
+    # doc = @client.create_document({ '@class' => CLASS, '@version' => 2, 'prop1' => 1, 'prop2' => 'text' })
+    # OrientDB bug https://github.com/orientechnologies/orientdb/issues/3657
+    # assert_equal 0, doc.doc_version
 
     # no effect if an unknown class
     doc = @client.create_document({ '@class' => 'unknown_class', 'a' => 11, 'b' => 'text1' })
@@ -76,8 +77,8 @@ class TestDocumentCrud < Test::Unit::TestCase
     assert_equal CLASS, doc.doc_class
     assert_equal created.doc_rid, doc.doc_rid
 
-    # FAIL: https://github.com/orientechnologies/orientdb/issues/3657
-    assert_equal 0, doc.doc_version
+    # https://github.com/orientechnologies/orientdb/issues/3657
+    assert doc.doc_version >= 1
     assert_equal 'd', doc.doc_type
     assert_equal 1, doc['prop1']
     assert_equal 'text', doc['prop2']


### PR DESCRIPTION
Last one ^^, this one provides fixes for OrientDB 2 (tested against 2.0.3)
Please note it breaks with ODB < 1.5 (before the new plocal storage engine), so maybe you want to merge in another branch ?

Also, is this gem still active ? Do you have any feedback on using it in a Rails app (do's and don't) ?

See also #30
