### PR TITLE
Increase default REST client error message length.

### DIFF
--- a/lib/orientdb4r/rest/client.rb
+++ b/lib/orientdb4r/rest/client.rb
@@ -448,7 +448,7 @@ module Orientdb4r
       ###
       # Composes message of an error raised if the HTTP response doesn't
       # correspond with expectation.
-      def compose_error_message(http_response, max_len=200)
+      def compose_error_message(http_response, max_len=300)
         msg = http_response.body.gsub("\n", ' ')
         msg = "#{msg[0..max_len]} ..." if msg.size > max_len
         msg


### PR DESCRIPTION
Some Orientdb errors are a fair bit longer than 200 chars, and in order to correctly handle ServerErrors by matching on exception messages, more than 200 chars are required, e.g. `500 Internal Server Error:
com.orientechnologies.orient.server.distributed.ODistributedException: Error on execution distributed CREATE_RECORD --> com.orientechnologies.orient.core.storage.ORecordDupl ...`

Also, @veny do you think it would be useful for this gem to provide more specific ruby errors for certain ODB server errors?

For example, we often just ignore duplicate recored exceptions in our application, which have a slightly different message depending on whether you're using ODB in standalone vs. distributed mode; we sometimes just treat `java.lang.NegativeArraySizeException` as a 404; we sometimes just retry code that resulted in `Conflict: com.orientechnologies.orient.core.exception.OConcurrentModificationException`.

I would be happy to attempt this, if you think it would be desirable, though am not sure the best way to write tests for this... Also, the list would definitely not be exhaustive, but I still think it could be helpful.