### PR TITLE
excon library compatibility

### DIFF
--- a/lib/orientdb4r/rest/client.rb
+++ b/lib/orientdb4r/rest/client.rb
@@ -103,7 +103,12 @@ module Orientdb4r
       # https://groups.google.com/forum/?fromgroups=#!topic/orient-database/R0VoOfIyDng
       #decorate_classes_with_model(rslt['classes']) unless rslt['classes'].nil?
 
-      Orientdb4r::logger.info "successfully connected to server, code=#{rslt.code}"
+      if @connection_library == :excon
+        Orientdb4r::logger.info "successfully connected to server, code=#{http_response.code}"
+      else
+        Orientdb4r::logger.info "successfully connected to server, code=#{rslt.code}"
+      end
+
       @connected = true
       @connected
     end

--- a/lib/orientdb4r/rest/excon_node.rb
+++ b/lib/orientdb4r/rest/excon_node.rb
@@ -85,8 +85,9 @@ module Orientdb4r
 
         options = {}
         options[:proxy] = proxy unless proxy.nil?
+        options[:scheme], options[:host], options[:port]=url.scan(/(.*):\/\/(.*):([0-9]*)/).first
 
-        @connection ||= Excon::Connection.new(url, options)
+        @connection ||= Excon::Connection.new(options)
         #:read_timeout => self.class.read_timeout,
         #:write_timeout => self.class.write_timeout,
         #:connect_timeout => self.class.connect_timeout


### PR DESCRIPTION
I made few small changes in order to be able to use the excon library interface. (I needed to establish a persistent connection to the database using: $client = Orientdb4r.client :connection_library => :excon)

The fix seems to make orientdb4r compatible with the current excon version (excon-0.49.0).
