### PR TITLE
Update to OrientDB 2.2.8

### DIFF
--- a/lib/orientdb4r.rb
+++ b/lib/orientdb4r.rb
@@ -64,8 +64,16 @@ module Orientdb4r
   end
 
   ###
+  # Error indicating that the request is malformed of invalid somehow.
+  class InvalidRequestError < OrientdbError; end
+
+  ###
   # Error indicating that access to the resource requires user authentication.
   class UnauthorizedError < OrientdbError; end
+
+  ###
+  # Error indicating a conflict between database state and the request
+  class StateConflictError < OrientdbError; end
 
   ###
   # Error indicating that the server encountered an unexpected condition which prevented it from fulfilling the request.

--- a/lib/orientdb4r.rb
+++ b/lib/orientdb4r.rb
@@ -27,6 +27,7 @@ module Orientdb4r
   autoload :RoundRobin,       'orientdb4r/load_balancing'
   autoload :DocumentMetadata, 'orientdb4r/rest/model'
 
+  MUTEX_CLIENT = Mutex.new
 
   class << self
 
@@ -42,7 +43,7 @@ module Orientdb4r
         return options.delete(:binary) ? Binary::BinClient.new(options) : RestClient.new(options)
       end
 
-      Thread.exclusive {
+      MUTEX_CLIENT.synchronize {
         client = options.delete(:binary) ? Binary::BinClient.new(options) : RestClient.new(options)
         Thread.current[:orientdb_client] ||= client
         #Thread.current[:orientdb_client] ||= BinClient.new options

--- a/lib/orientdb4r/rest/restclient_node.rb
+++ b/lib/orientdb4r/rest/restclient_node.rb
@@ -39,7 +39,7 @@ module Orientdb4r
 
         # store session ID if received to reuse in next request
         sessid = response.cookies[SESSION_COOKIE_NAME]
-        if session_id != sessid and use_session
+        if sessid and session_id != sessid and use_session
           @session_id = sessid
           Orientdb4r::logger.debug "new session id: #{session_id}"
         end

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -80,7 +80,7 @@ class TestDatabase < Test::Unit::TestCase
       @client.get_database :database => 'UniT', :user => 'admin', :password => 'admin'
     end
     # creating an existing DB
-    assert_raise Orientdb4r::ServerError do
+    assert_raise Orientdb4r::StateConflictError do
       @client.create_database :database => 'UniT', :user => 'root', :password => DB_ROOT_PASS
     end
     # insufficient rights

--- a/test/test_ddo.rb
+++ b/test/test_ddo.rb
@@ -93,7 +93,7 @@ class TestDdo < Test::Unit::TestCase
     assert_equal 'OUser', clazz.super_class
 
     # bad super class
-    assert_raise Orientdb4r::ServerError do @client.create_class(CLASS, :extends => 'nonExistingSuperClass'); end
+    assert_raise Orientdb4r::InvalidRequestError do @client.create_class(CLASS, :extends => 'nonExistingSuperClass'); end
   end
 
 

--- a/test/test_dmo.rb
+++ b/test/test_dmo.rb
@@ -49,7 +49,7 @@ class TestDmo < Test::Unit::TestCase
     assert_equal urids.size, @client.query("SELECT FROM #{CLASS} WHERE prop2 = 'linkset'")[0]['friends'].size
 
     # table doesn't exist
-    assert_raise Orientdb4r::ServerError do
+    assert_raise Orientdb4r::InvalidRequestError do
       @client.command "INSERT INTO #{CLASS}x (prop1, prop2, friends) VALUES (1, 'linkset', [#{urids.join(',')}])"
     end
     # bad syntax
@@ -92,7 +92,7 @@ class TestDmo < Test::Unit::TestCase
     assert_equal 1, gr.select { |e| e if e['@class'] == 'ORole' }.size
 
     # table doesn't exist
-    assert_raise Orientdb4r::ServerError do
+    assert_raise Orientdb4r::InvalidRequestError do
       @client.query 'SELECT FROM OUserX'
     end
     # bad syntax
@@ -105,7 +105,7 @@ class TestDmo < Test::Unit::TestCase
     assert_instance_of Array, entries
     assert entries.empty?
     # try to find entry in a non-existing cluster
-    assert_raise Orientdb4r::ServerError do @client.query 'SELECT FROM #111:1111'; end
+    assert_raise Orientdb4r::NotFoundError do @client.query 'SELECT FROM #111:1111'; end
     # used for INSERT
     assert_raise Orientdb4r::ServerError do
       @client.query "INSERT INTO #{CLASS} (prop1, prop2, friends) VALUES (0, 'string0', [])"

--- a/test/test_document_crud.rb
+++ b/test/test_document_crud.rb
@@ -157,7 +157,7 @@ class TestDocumentCrud < Test::Unit::TestCase
     doc = @client.create_document( { '@class' => CLASS, 'prop1' => 1, 'prop2' => 'text' })
     assert_raise Orientdb4r::ServerError do @client.batch(nil); end
     assert_raise Orientdb4r::ServerError do @client.batch({:foo => :baz, :bar => :alfa}); end # bad structure
-    assert_raise Orientdb4r::ServerError do @client.batch({:operations => [{:type => :d, :record => {'@rid' => '#123:456'}}]}); end # bad cluster
+    assert_raise Orientdb4r::NotFoundError do @client.batch({:operations => [{:type => :d, :record => {'@rid' => '#123:456'}}]}); end # bad cluster
     assert_nothing_thrown do @client.batch({:operations => [{:type => :d, :record => {'@rid' => "##{doc.doc_rid.cluster_id}:678"}}]}); end # bad RID is not problem
   end
 


### PR DESCRIPTION
OrientDB changed some of REST responses to better error codes.

This commit updates the error code handling and create a couple of new exceptions to correctly handle them.

(unfortunately, a previous PR is going with this one. I can separate them, but let me know if it's really necessary :) )